### PR TITLE
37 publish docker image to Github Container Registry

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -97,16 +97,17 @@ jobs:
         uses: sonarsource/sonarqube-scan-action@v6
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-
+  
+  #This jobs set up a docker image and push to GitHub Container Registry (GHCR)
   publish-ghcr:
     runs-on: ubuntu-latest
     needs: [docker-compose]    # only run if tests pass
     if: ${{ github.ref == 'refs/heads/main' }}  # publish only on main branch
-    permissions:
+    permissions: #Github_token by default has read only access for centent. It is needed to set the write permission
       contents: read
       packages: write
 
-    strategy:
+    strategy: #Images of both front-end and back-end are built and pushed to GHCR
       matrix:
         include:
           - name: backend


### PR DESCRIPTION
- Configuring the ci-pipeline.yml for publishing Docker Image to Github Container Registry
- Tested in branch 37-Publish-Docker-Image-to-GHCR
