### PR TITLE
Rename timelineJobController and timelineJobRouter

### DIFF
--- a/Back-End/src/controllers/jobController.ts
+++ b/Back-End/src/controllers/jobController.ts
@@ -13,7 +13,7 @@ interface CachedJobResult<T = unknown> {
   };
 }
 
-export const getTimelineByJobId: RequestHandler<GetResultParams> = async (
+export const getByJobId: RequestHandler<GetResultParams> = async (
   req,
   res,
 ) => {

--- a/Back-End/src/index.ts
+++ b/Back-End/src/index.ts
@@ -19,7 +19,7 @@ import feedbackRouter from '@routes/feedbackRoutes';
 import userRouter from '@routes/userRoutes';
 import sectionsRoutes from '@routes/sectionsRoutes';
 import uploadRouter from '@routes/uploadRoutes';
-import timelineJobRouter from '@routes/timelineJobRoutes';
+import jobRouter from '@routes/jobRoutes';
 
 import swaggerUi from 'swagger-ui-express';
 import { swaggerSpec } from './swagger';
@@ -117,7 +117,7 @@ app.use('/admin', adminRouter);
 app.use('/feedback', feedbackRouter);
 app.use('/section', sectionsRoutes);
 app.use('/upload', uploadRouter);
-app.use('/jobs', timelineJobRouter);
+app.use('/jobs', jobRouter);
 
 //Handle 404
 app.use(notFoundHandler);

--- a/Back-End/src/routes/jobRoutes.ts
+++ b/Back-End/src/routes/jobRoutes.ts
@@ -1,0 +1,8 @@
+import express from 'express';
+import { getByJobId } from '../controllers/jobController';
+
+const router = express.Router();
+
+router.get('/:jobId', getByJobId);
+
+export default router;

--- a/Back-End/src/routes/timelineJobRoutes.ts
+++ b/Back-End/src/routes/timelineJobRoutes.ts
@@ -1,8 +1,0 @@
-import express from 'express';
-import { getTimelineByJobId } from '../controllers/timelineJobController';
-
-const router = express.Router();
-
-router.get('/:jobId', getTimelineByJobId);
-
-export default router;

--- a/Back-End/src/tests/jobController.test.js
+++ b/Back-End/src/tests/jobController.test.js
@@ -8,7 +8,7 @@ jest.mock('../lib/cache', () => ({
 }));
 
 // Import after mocks
-const { getTimelineByJobId } = require('../controllers/timelineJobController');
+const { getByJobId } = require('../controllers/jobController');
 
 const createMockResponse = () => {
   const res = {};
@@ -17,7 +17,7 @@ const createMockResponse = () => {
   return res;
 };
 
-describe('getTimelineByJobId', () => {
+describe('getByJobId', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
@@ -28,7 +28,7 @@ describe('getTimelineByJobId', () => {
     };
     const res = createMockResponse();
 
-    await getTimelineByJobId(req, res, jest.fn());
+    await getByJobId(req, res, jest.fn());
 
     expect(res.status).toHaveBeenCalledWith(404);
     expect(res.json).toHaveBeenCalledWith({
@@ -45,7 +45,7 @@ describe('getTimelineByJobId', () => {
 
     mockGetJobResult.mockResolvedValueOnce(null);
 
-    await getTimelineByJobId(req, res, jest.fn());
+    await getByJobId(req, res, jest.fn());
 
     expect(mockGetJobResult).toHaveBeenCalledWith('job-123');
     expect(res.status).toHaveBeenCalledWith(410);
@@ -69,7 +69,7 @@ describe('getTimelineByJobId', () => {
 
     mockGetJobResult.mockResolvedValueOnce(cached);
 
-    await getTimelineByJobId(req, res, jest.fn());
+    await getByJobId(req, res, jest.fn());
 
     expect(mockGetJobResult).toHaveBeenCalledWith('job-456');
     expect(res.json).toHaveBeenCalledWith({
@@ -89,7 +89,7 @@ describe('getTimelineByJobId', () => {
 
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 
-    await getTimelineByJobId(req, res, jest.fn());
+    await getByJobId(req, res, jest.fn());
 
     expect(mockGetJobResult).toHaveBeenCalledWith('job-error');
     expect(res.status).toHaveBeenCalledWith(500);

--- a/Back-End/src/tests/jobRoutes.test.js
+++ b/Back-End/src/tests/jobRoutes.test.js
@@ -2,19 +2,19 @@ const express = require('express');
 const request = require('supertest');
 
 // --- Mock the controller ---
-const mockGetTimelineByJobId = jest.fn((req, res) => {
+const mockGetByJobId = jest.fn((req, res) => {
   return res.status(200).json({
     called: true,
     jobId: req.params.jobId,
   });
 });
 
-jest.mock('../controllers/timelineJobController', () => ({
-  getTimelineByJobId: mockGetTimelineByJobId,
+jest.mock('../controllers/jobController', () => ({
+  getByJobId: mockGetByJobId,
 }));
 
 // --- Import the router AFTER mocks ---
-const routerModule = require('../routes/timelineJobRoutes'); // adjust path if needed
+const routerModule = require('../routes/jobRoutes'); // adjust path if needed
 const router = routerModule.default || routerModule;
 
 // Build a small app using just this router
@@ -27,14 +27,14 @@ describe('GET /jobs/:jobId', () => {
     jest.clearAllMocks();
   });
 
-  it('calls getTimelineByJobId with the correct jobId and returns its response', async () => {
+  it('calls getByJobId with the correct jobId and returns its response', async () => {
     const res = await request(app).get('/jobs/abc123');
 
     // Controller should be called once
-    expect(mockGetTimelineByJobId).toHaveBeenCalledTimes(1);
+    expect(mockGetByJobId).toHaveBeenCalledTimes(1);
 
     // First arg is req → check params
-    const reqArg = mockGetTimelineByJobId.mock.calls[0][0];
+    const reqArg = mockGetByJobId.mock.calls[0][0];
     expect(reqArg.params.jobId).toBe('abc123');
 
     // Response should match what the mock sent


### PR DESCRIPTION
Renamed timelineJobController to jobController and updated all references, including route and test files, to use the new job naming. Replaced timelineJobRoutes with jobRoutes and updated the main app router accordingly. This improves clarity and consistency in naming related to job operations.