### PR TITLE
hotfix: remove unnecessary encoding of returnUrl

### DIFF
--- a/ts-front-end/src/pages/TimelinePage.tsx
+++ b/ts-front-end/src/pages/TimelinePage.tsx
@@ -48,7 +48,7 @@ const TimeLinePage: React.FC = () => {
   const handleOpenModal = (open: boolean, type: string) => {
     if (type === "save" && !user) {
       toast.info("Please sign in or sign up to save your timeline");
-      const returnUrl = encodeURIComponent(globalThis.location.pathname);
+      const returnUrl = globalThis.location.pathname;
       localStorage.setItem("redirectAfterLogin", returnUrl);
       navigate(`/signin`);
       return;


### PR DESCRIPTION
the encoding messes up the redirect that happens on the student page