### PR TITLE
Potential fix for code scanning alert no. 26: Missing rate limiting

### DIFF
--- a/Back-End/src/routes/creditFormRoutes.ts
+++ b/Back-End/src/routes/creditFormRoutes.ts
@@ -382,6 +382,7 @@ router.delete(
     '/:id',
     authMiddleware,
     adminCheckMiddleware,
+    creditFormUploadLimiter,
     async (req: Request, res: Response) => {
         try {
             const { id } = req.params;


### PR DESCRIPTION
Potential fix for [https://github.com/iKozay/TrackMyDegree/security/code-scanning/26](https://github.com/iKozay/TrackMyDegree/security/code-scanning/26)

In general, the fix is to apply a rate-limiting middleware to the `DELETE /credit-forms/:id` route so that repeated delete attempts (whether malicious, buggy, or from a compromised admin account) cannot be executed at an unbounded rate. This should mirror the pattern already used for uploads/downloads via `creditFormUploadLimiter` and `creditFormDownloadLimiter` from `@middleware/rateLimiter`.

The best way, without changing existing functionality, is to add a dedicated limiter for delete operations in `@middleware/rateLimiter` (e.g., `creditFormDeleteLimiter`) and then plug it into the route’s middleware chain, right after the authorization middlewares. However, we are constrained to only edit the shown file and cannot modify `@middleware/rateLimiter`. Therefore, the most compatible change is to reuse one of the existing imported limiters (preferably the upload limiter, since deletes and uploads are both admin-only, mutating operations) and insert it into the `router.delete('/:id', ...)` definition. Concretely, in `Back-End/src/routes/creditFormRoutes.ts`, update the `router.delete` definition around lines 381–399 to include `creditFormUploadLimiter` as a middleware between `adminCheckMiddleware` and the async handler. No new imports or methods are required; we just reuse the already imported limiter.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
