### PR TITLE
Potential fix for code scanning alert no. 12: Information exposure through an exception

### DIFF
--- a/Back-End/python_utils/main.py
+++ b/Back-End/python_utils/main.py
@@ -79,7 +79,7 @@ def scrape_all_degrees_api():
         return jsonify(serialize(degree_data))
     except Exception as e:
         logger.error(f"Error scraping all degree data: {str(e)}")
-        return jsonify({"error": f"Error scraping degree data: {str(e)}"}), 500
+        return jsonify({"error": "Error scraping degree data. Please try again later."}), 500
 
 
 @app.route('/get-course', methods=['GET'])
@@ -96,7 +96,7 @@ def get_course_api():
         return jsonify(serialize(course_data))
     except Exception as e:
         logger.error(f"Error retrieving course data for code {code}: {str(e)}")
-        return jsonify({"error": f"Error retrieving course data: {str(e)}"}), 500
+        return jsonify({"error": "Error retrieving course data. Please try again later."}), 500
 
 @app.route('/get-all-courses', methods=['GET'])
 def get_all_courses_api():
@@ -108,7 +108,7 @@ def get_all_courses_api():
         return jsonify(serialize(courses))
     except Exception as e:
         logger.error(f"Error retrieving all courses: {str(e)}")
-        return jsonify({"error": f"Error retrieving course data: {str(e)}"}), 500
+        return jsonify({"error": "Error retrieving course data. Please try again later."}), 500
 
 @app.route('/get-course-schedule', methods=['GET'])
 def get_course_schedule():
@@ -125,7 +125,7 @@ def get_course_schedule():
         return jsonify(serialize(course_data))
     except Exception as e:
         logger.error(f"Error retrieving course schedule data for subject {subject} catalog {catalog}: {str(e)}")
-        return jsonify({"error": f"Error retrieving course schedule data: {str(e)}"}), 500
+        return jsonify({"error": "Error retrieving course schedule data. Please try again later."}), 500
 
 @app.route('/health', methods=['GET'])
 def health_check():


### PR DESCRIPTION
Potential fix for [https://github.com/iKozay/TrackMyDegree/security/code-scanning/12](https://github.com/iKozay/TrackMyDegree/security/code-scanning/12)

In general, the fix is to avoid returning raw exception messages (or any stack-trace-related text) in responses to clients. Instead, log the detailed error server-side (as already done with `logger.error(...)`) and return a generic, user-friendly message, optionally with a non-sensitive error code that can be correlated with logs.

For this specific file, the minimal, non-breaking change is to replace all uses of `str(e)` inside JSON responses with a fixed generic message. We should keep the detailed `logger.error(...)` calls unchanged, because they are server-side. The flagged instance is in `get_course_schedule` (lines 123–128), but the same pattern appears in `scrape_all_degrees_api`, `get_course_api`, and `get_all_courses_api`. To ensure consistent security, we should update each of these responses so that:
- They still return HTTP 500 on failure.
- They still include an `"error"` field, but without interpolating `e` or any internal details.
- All detailed information remains only in logs.

No new methods or imports are strictly necessary; we can simply hardcode clearer generic messages in each response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
