### PR TITLE
Strengthen `/:id` Route Validation and Improve Tests

### DIFF
--- a/Back-End/src/routes/courseRoutes.ts
+++ b/Back-End/src/routes/courseRoutes.ts
@@ -121,14 +121,15 @@ router.get('/by-degree/:degreeId', cacheGET(COURSE_BY_DEGREE_CACHE_TTL), async (
   try {
     const { degreeId } = req.params;
 
-    if (!degreeId) {
+    const cleanId = (degreeId as string)?.trim();
+    if (!cleanId) {
       res.status(HTTP.BAD_REQUEST).json({
         error: 'Degree ID is required',
       });
       return;
     }
     const coursePools =
-      await degreeController.getCoursePoolsForDegree(degreeId as string);
+      await degreeController.getCoursePoolsForDegree(cleanId);
 
     // Fetch full course pool objects for each ID
     const populatedPools = await Promise.all(
@@ -200,14 +201,15 @@ router.get('/:code', cacheGET(COURSE_CACHE_TTL), async (req: Request, res: Respo
   try {
     const { code } = req.params;
 
-    if (!code) {
+    const cleanCode = (code as string)?.trim();
+    if (!cleanCode) {
       res.status(HTTP.BAD_REQUEST).json({
         error: 'Course code is required',
       });
       return;
     }
 
-    const course = await courseController.getCourseByCode(code as string);
+    const course = await courseController.getCourseByCode(cleanCode);
     res.status(HTTP.OK).json(course);
   } catch (error) {
     console.error('Error in GET /courses/:code', error);

--- a/Back-End/src/routes/degreeRoutes.ts
+++ b/Back-End/src/routes/degreeRoutes.ts
@@ -65,7 +65,8 @@ router.get('/:id', cacheGET(DEGREE_CACHE_TTL), async (req: Request, res: Respons
   try {
     const { id } = req.params;
 
-    if (!id) {
+    const cleanId = (id as string)?.trim();
+    if (!cleanId) {
       res.status(HTTP.BAD_REQUEST).json({
         error: DEGREE_ID_REQUIRED,
       });
@@ -162,7 +163,8 @@ router.get('/:id/credits', cacheGET(DEGREE_CACHE_TTL), async (req: Request, res:
   try {
     const { id } = req.params;
 
-    if (!id) {
+    const cleanId = (id as string)?.trim();
+    if (!cleanId) {
       res.status(HTTP.BAD_REQUEST).json({
         error: DEGREE_ID_REQUIRED,
       });
@@ -225,7 +227,8 @@ router.get('/:id/credits', cacheGET(DEGREE_CACHE_TTL), async (req: Request, res:
 router.get('/:id/coursepools', cacheGET(DEGREE_CACHE_TTL), async (req: Request, res: Response) => {
   try {
     const { id } = req.params;
-    if (!id) {
+    const cleanId = (id as string)?.trim();
+    if (!cleanId) {
       res.status(HTTP.BAD_REQUEST).json({
         error: DEGREE_ID_REQUIRED,
       });

--- a/Back-End/src/tests/courseRoutes.test.js
+++ b/Back-End/src/tests/courseRoutes.test.js
@@ -6,6 +6,12 @@ const courseRoutes = require('../routes/courseRoutes').default;
 const { Course } = require('../models/course');
 const { courseController } = require('../controllers/courseController');
 
+
+jest.mock('../lib/cache', () => ({
+  cacheGet: jest.fn().mockResolvedValue(null),
+  cacheSet: jest.fn().mockResolvedValue(true),
+}));
+
 describe('Course Routes', () => {
   let mongoServer, mongoUri, app;
 
@@ -336,8 +342,8 @@ describe('Course Routes', () => {
       // This test is for the route parameter validation
       // Since Express handles route params, we test with empty string or invalid format
       const response = await request(app)
-        .get('/courses/by-degree/')
-        .expect(404); // Express will return 404 for malformed route
+        .get('/courses/by-degree/%20') // Simulate empty/whitespace degreeId
+        .expect(400);
 
       // The route expects a degreeId parameter, so we test error handling
       // by checking what happens when degreeId is not found
@@ -465,18 +471,10 @@ describe('Course Routes', () => {
       expect(response.body.error).toContain('not found');
     });
 
-    it('should return 400 if code is missing', async () => {
-      const testApp = express();
-      testApp.use(express.json());
-      testApp.get('/test', (req, res) => {
-        if (!req.params.code) {
-          res.status(400).json({ error: 'Course code is required' });
-        }
-      });
-
-      const response = await request(testApp).get('/test');
-      expect(response.status).toBe(400);
-    });
+    it('should return 400 if code is empty or whitespace', async () => {
+     const response = await request(app).get('/courses/%20');
+     expect(response.status).toBe(400);
+   });
 
     it('should handle server errors', async () => {
       const spy = jest

--- a/Back-End/src/tests/degreeRoutes.test.js
+++ b/Back-End/src/tests/degreeRoutes.test.js
@@ -14,6 +14,11 @@ const app = express();
 app.use(express.json());
 app.use('/degree', degreeRoutes);
 
+jest.mock('../lib/cache', () => ({
+  cacheGet: jest.fn().mockResolvedValue(null),
+  cacheSet: jest.fn().mockResolvedValue(true),
+}));
+
 describe('Degree Routes', () => {
   let mongoServer, mongoUri;
 
@@ -219,18 +224,10 @@ describe('Degree Routes', () => {
       expect(response.body.error).toContain('does not exist');
     });
 
-    it('should return 400 if id is missing (route param simulation)', async () => {
-      const testApp = express();
-      testApp.use(express.json());
-      testApp.get('/test', (req, res) => {
-        if (!req.params.id) {
-          res.status(400).json({ error: 'Degree ID is required' });
-        }
-      });
-
-      const response = await request(testApp).get('/test');
-      expect(response.status).toBe(400);
-    });
+    it('should return 400 if id is empty or whitespace', async () => {
+  const response = await request(app).get('/degree/%20');
+  expect(response.status).toBe(400);
+});
 
     it('should handle errors during fetch via Degree.findById rejection', async () => {
       const originalFindById = Degree.findById;
@@ -315,16 +312,8 @@ describe('Degree Routes', () => {
       expect(response.body.error).toContain('does not exist');
     });
 
-    it('should return 400 if id is missing (route param simulation)', async () => {
-      const testApp = express();
-      testApp.use(express.json());
-      testApp.get('/test', (req, res) => {
-        if (!req.params.id) {
-          res.status(400).json({ error: 'Degree ID is required' });
-        }
-      });
-
-      const response = await request(testApp).get('/test');
+   it('should return 400 if id is empty or whitespace', async () => {
+      const response = await request(app).get('/degree/%20/credits');
       expect(response.status).toBe(400);
     });
 
@@ -399,16 +388,8 @@ describe('Degree Routes', () => {
       expect(response.body.error).toContain('does not exist');
     });
 
-    it('should return 400 if id is missing', async () => {
-      const testApp = express();
-      testApp.use(express.json());
-      testApp.get('/test', (req, res) => {
-        if (!req.params.id) {
-          res.status(400).json({ error: 'Degree ID is required' });
-        }
-      });
-
-      const response = await request(testApp).get('/test');
+    it('should return 400 if id is empty or whitespace', async () => {
+      const response = await request(app).get('/degree/%20/coursepools');
       expect(response.status).toBe(400);
     });
 

--- a/Back-End/src/tests/timelineRoutes.test.js
+++ b/Back-End/src/tests/timelineRoutes.test.js
@@ -309,20 +309,12 @@ it('should return 410 if cached result expired', async () => {
       expect(response.body).toHaveProperty('error');
     });
 
-    it('should return 400 if id is missing', async () => {
-      const testApp = express();
-      testApp.use(express.json());
-      testApp.put('/test', (req, res) => {
-        if (!req.params.id) {
-          res.status(400).json({ error: 'Timeline ID is required' });
-        }
-      });
-
-      const response = await request(testApp)
-        .put('/test')
-        .send({ name: 'Test' });
+    it('should return 400 if id is empty or whitespace', async () => {
+      const response = await request(app).put('/timeline/%20');
       expect(response.status).toBe(400);
     });
+
+    
 
     it('should handle server errors', async () => {
       // Mock timelineController.updateTimeline to throw an error
@@ -429,18 +421,10 @@ it('should return 410 if cached result expired', async () => {
       expect(response.body.error).toContain('does not exist');
     });
 
-    it('should return 400 if id is missing', async () => {
-      const testApp = express();
-      testApp.use(express.json());
-      testApp.delete('/test', (req, res) => {
-        if (!req.params.id) {
-          res.status(400).json({ error: 'Timeline ID is required' });
-        }
-      });
-
-      const response = await request(testApp).delete('/test');
-      expect(response.status).toBe(400);
-    });
+     it('should return 400 if id is empty or whitespace', async () => {
+         const response = await request(app).get('/timeline/%20');
+         expect(response.status).toBe(400);
+       });
 
     it('should handle server errors', async () => {
       // Mock timelineController.deleteTimeline to throw an error
@@ -592,17 +576,9 @@ it('should return 410 if cached result expired', async () => {
     });
 
     it('should return 400 if userId is missing', async () => {
-      const testApp = express();
-      testApp.use(express.json());
-      testApp.delete('/test', (req, res) => {
-        if (!req.params.userId) {
-          res.status(400).json({ error: 'User ID is required' });
-        }
-      });
-
-      const response = await request(testApp).delete('/test');
-      expect(response.status).toBe(400);
-    });
+         const response = await request(app).delete('/timeline/user/%20');
+         expect(response.status).toBe(400);
+       });
 
     it('should handle server errors', async () => {
       // Mock timelineController.deleteAllUserTimelines to throw an error


### PR DESCRIPTION
## Problem
Routes using the `/:id` pattern assumed the `id` parameter is always valid if present. While Express ensures the parameter exists, it can still contain invalid values such as whitespace (`%20`) or empty-like strings.

Some existing tests simulated impossible scenarios, like missing `req.params.id`, which do not reflect real-world behavior.


## Solution
- Updated all `/:id` route handlers to validate IDs using `trim()` before checking emptiness:

```ts
const cleanId = (id as string)?.trim();
if (!cleanId) return res.status(400).json({ error: 'ID is required' });
Requests with invalid IDs (e.g., /degree/%20) now return 400 Bad Request.
```
- Removed artificial tests simulating missing route params in:
  - `courseRoutes.test`
  - `degreeRoutes.test`
  - `timelineRoutes.test`
- Added new tests covering realistic invalid inputs, such as empty or whitespace-only IDs.
- Mocked cache in courseRoutes.test and degreeRoutes.test to speed up test execution.
## Scope
- Routes affected: courseRoute, degreeRoute
- Tests updated: courseRoutes.test, degreeRoutes.test, timelineRoutes.test