### PR TITLE
fix: prevent crash in PoolCourseList when course is undefined

### DIFF
--- a/ts-front-end/src/components/PoolCoursesList.tsx
+++ b/ts-front-end/src/components/PoolCoursesList.tsx
@@ -27,9 +27,9 @@ export const PoolCoursesList: React.FC<PoolCoursesListProps> = ({
     <div className="pool-courses">
       {idsToRender.map((courseId, index) => {
         const course = courses[courseId];
+        if (!course) return null;
         const isCompleted = course.status.status === "completed";
         const isPlanned = course.status.status === "planned";
-        if (!course) return null;
         if (showIncompleted && (isCompleted || isPlanned)) return null;
 
         return (


### PR DESCRIPTION
## Description
Moved the guard clause `if (!course) return null` to **before** accessing `course.status`. This prevents TypeError when a course in the pool is undefined or when a coursePool is empty.

closes: #422