### PR TITLE
Improper type validation fix

### DIFF
--- a/Back-End/src/routes/userRoutes.ts
+++ b/Back-End/src/routes/userRoutes.ts
@@ -245,6 +245,22 @@ router.patch('/:id', async (req: Request<{ id: string }>, res: Response) => {
     const { id } = req.params;
     const { fullname, currentPassword, newPassword } = req.body;
 
+    if (fullname !== undefined && typeof fullname !== 'string') {
+      return res
+        .status(HTTP.BAD_REQUEST)
+        .json({ error: 'fullname must be a string' });
+    }
+    if (currentPassword !== undefined && typeof currentPassword !== 'string') {
+      return res
+        .status(HTTP.BAD_REQUEST)
+        .json({ error: 'currentPassword must be a string' });
+    }
+    if (newPassword !== undefined && typeof newPassword !== 'string') {
+      return res
+        .status(HTTP.BAD_REQUEST)
+        .json({ error: 'newPassword must be a string' });
+    }
+
     if (!mongoose.Types.ObjectId.isValid(id)) {
       return res.status(HTTP.BAD_REQUEST).json({ error: INVALID_ID_FORMAT });
     }

--- a/Back-End/src/routes/userRoutes.ts
+++ b/Back-End/src/routes/userRoutes.ts
@@ -290,7 +290,17 @@ router.put('/:id', async (req: Request, res: Response) => {
     const { id } = req.params;
     const updates = req.body;
 
-     if (!mongoose.Types.ObjectId.isValid(id as string)) {
+    if (
+      typeof updates !== 'object' ||
+      Array.isArray(updates) ||
+      updates === null
+    ) {
+      return res
+        .status(HTTP.BAD_REQUEST)
+        .json({ error: 'Invalid request body' });
+    }
+
+    if (!mongoose.Types.ObjectId.isValid(id as string)) {
       return res.status(HTTP.BAD_REQUEST).json({
         error: INVALID_ID_FORMAT,
       });

--- a/Back-End/src/tests/userRoutes.test.js
+++ b/Back-End/src/tests/userRoutes.test.js
@@ -601,6 +601,16 @@ describe('User Routes', () => {
   expect(res.body.error).toBe('fullname must be a string');
 });
 
+it('should return 400 if currentPassword is not a string', async () => {
+  const res = await request(app)
+    .patch(`/users/${testUser._id}`)
+    .send({ currentPassword: 123, newPassword: 'validpass' })
+    .expect(400);
+
+  expect(res.body.error).toBe('currentPassword must be a string');
+});
+
+
   // Additional tests for uncovered error handling branches
   describe('Error handling edge cases', () => {
     beforeEach(async () => {

--- a/Back-End/src/tests/userRoutes.test.js
+++ b/Back-End/src/tests/userRoutes.test.js
@@ -592,7 +592,14 @@ describe('User Routes', () => {
   });
 });
 
-   
+   it('should return 400 if fullname is not a string', async () => {
+  const res = await request(app)
+    .patch(`/users/${testUser._id}`)
+    .send({ fullname: ['not', 'a', 'string'] })
+    .expect(400);
+
+  expect(res.body.error).toBe('fullname must be a string');
+});
 
   // Additional tests for uncovered error handling branches
   describe('Error handling edge cases', () => {

--- a/Back-End/src/tests/userRoutes.test.js
+++ b/Back-End/src/tests/userRoutes.test.js
@@ -771,6 +771,15 @@ it('should return 400 if newPassword is not a string', async () => {
       });
     });
 
+    it('should return 400 if body is an array', async () => {
+  const res = await request(app)
+    .put(`/users/${testUser._id}`)
+    .send([{ fullname: 'hacked' }])
+    .expect(400);
+
+  expect(res.body.error).toBe('Invalid request body');
+});
+
     describe('DELETE /users/:id error branches', () => {
       it('should handle "does not exist" error specifically', async () => {
         const originalDeleteUser = require('../controllers/userController')

--- a/Back-End/src/tests/userRoutes.test.js
+++ b/Back-End/src/tests/userRoutes.test.js
@@ -778,7 +778,17 @@ it('should return 400 if newPassword is not a string', async () => {
     .expect(400);
 
   expect(res.body.error).toBe('Invalid request body');
-});
+  });
+
+it('should return 400 if body is null', async () => {
+  const res = await request(app)
+    .put(`/users/${testUser._id}`)
+    .set('Content-Type', 'application/json')
+    .send('null')
+    .expect(400);
+
+  expect(res.body.error).toBe('Invalid request body');
+  });
 
     describe('DELETE /users/:id error branches', () => {
       it('should handle "does not exist" error specifically', async () => {

--- a/Back-End/src/tests/userRoutes.test.js
+++ b/Back-End/src/tests/userRoutes.test.js
@@ -780,15 +780,15 @@ it('should return 400 if newPassword is not a string', async () => {
   expect(res.body.error).toBe('Invalid request body');
   });
 
-it('should return 400 if body is null', async () => {
+it('should return 400 if body is a primitive string', async () => {
   const res = await request(app)
     .put(`/users/${testUser._id}`)
     .set('Content-Type', 'application/json')
-    .send('null')
+    .send('"just a string"')
     .expect(400);
 
   expect(res.body.error).toBe('Invalid request body');
-  });
+});
 
     describe('DELETE /users/:id error branches', () => {
       it('should handle "does not exist" error specifically', async () => {

--- a/Back-End/src/tests/userRoutes.test.js
+++ b/Back-End/src/tests/userRoutes.test.js
@@ -610,6 +610,14 @@ it('should return 400 if currentPassword is not a string', async () => {
   expect(res.body.error).toBe('currentPassword must be a string');
 });
 
+it('should return 400 if newPassword is not a string', async () => {
+  const res = await request(app)
+    .patch(`/users/${testUser._id}`)
+    .send({ newPassword: { value: 'hack' } })
+    .expect(400);
+
+  expect(res.body.error).toBe('newPassword must be a string');
+});
 
   // Additional tests for uncovered error handling branches
   describe('Error handling edge cases', () => {

--- a/Back-End/src/tests/userRoutes.test.js
+++ b/Back-End/src/tests/userRoutes.test.js
@@ -780,16 +780,6 @@ it('should return 400 if newPassword is not a string', async () => {
   expect(res.body.error).toBe('Invalid request body');
   });
 
-it('should return 400 if body is a primitive string', async () => {
-  const res = await request(app)
-    .put(`/users/${testUser._id}`)
-    .set('Content-Type', 'application/json')
-    .send('"just a string"')
-    .expect(400);
-
-  expect(res.body.error).toBe('Invalid request body');
-});
-
     describe('DELETE /users/:id error branches', () => {
       it('should handle "does not exist" error specifically', async () => {
         const originalDeleteUser = require('../controllers/userController')


### PR DESCRIPTION
Fix Improper Type Validation in userRoutes.ts — Closes #438 

- Added type checks for fullname, currentPassword, and newPassword in the PATCH /:id route — if any of these come in as a non-string type, the request is rejected with a 400 before any logic runs

- Added a type check for req.body in the PUT /:id route — rejects null, arrays, or non-objects before passing to the controller