### PR TITLE
fix(catalog): hydrate known course pools from DB degrees before patch validation

### DIFF
--- a/Back-End/src/services/catalog/applyCatalogPatch.ts
+++ b/Back-End/src/services/catalog/applyCatalogPatch.ts
@@ -238,6 +238,7 @@ export async function loadKnownEntityIds(payload: {
   diffs: Array<{
     entityType: VersionedEntityType;
     entityId: string;
+    patch?: JsonPatch;
   }>;
 }): Promise<ExistingEntityIds> {
   const newDegreeIds = new Set(payload.degrees.map((degree) => degree._id));
@@ -248,52 +249,65 @@ export async function loadKnownEntityIds(payload: {
   const { referencedDegreeIds, referencedCoursePoolIds, referencedCourseIds } =
     collectReferencedIds(payload);
 
-  const [existingDegrees, existingCoursePools, existingCourses] =
-    await Promise.all([
-      Degree.find(
-        {
-          _id: {
-            $in: Array.from(referencedDegreeIds),
-          },
-        },
-        { _id: 1 },
-      )
-        .lean()
-        .exec(),
-      CoursePool.find(
-        {
-          _id: {
-            $in: Array.from(referencedCoursePoolIds),
-          },
-        },
-        { _id: 1 },
-      )
-        .lean()
-        .exec(),
-      Course.find(
-        {
-          _id: {
-            $in: Array.from(referencedCourseIds),
-          },
-        },
-        { _id: 1 },
-      )
-        .lean()
-        .exec(),
-    ]);
+  const degreeIdsToHydrate = Array.from(referencedDegreeIds);
+
+  const degreesFromDb =
+    degreeIdsToHydrate.length > 0
+      ? await Degree.find(
+          { _id: { $in: degreeIdsToHydrate } },
+          { _id: 1, coursePools: 1 },
+        )
+          .lean<Array<{ _id: string; coursePools?: string[] }>>()
+          .exec()
+      : [];
+
+  const expandedCoursePoolIds = new Set<string>(referencedCoursePoolIds);
+  for (const degree of degreesFromDb) {
+    for (const poolId of degree.coursePools || []) {
+      expandedCoursePoolIds.add(String(poolId));
+    }
+  }
+
+  const poolIdsArray = Array.from(expandedCoursePoolIds);
+
+  const poolsFromDb =
+    poolIdsArray.length > 0
+      ? await CoursePool.find(
+          { _id: { $in: poolIdsArray } },
+          { _id: 1, courses: 1 },
+        )
+          .lean<Array<{ _id: string; courses?: string[] }>>()
+          .exec()
+      : [];
+
+  const expandedCourseIds = new Set<string>(referencedCourseIds);
+  for (const pool of poolsFromDb) {
+    for (const courseId of pool.courses || []) {
+      expandedCourseIds.add(String(courseId));
+    }
+  }
+
+  const courseIdsArray = Array.from(expandedCourseIds);
+
+  const coursesFromDb =
+    courseIdsArray.length > 0
+      ? await Course.find({ _id: { $in: courseIdsArray } }, { _id: 1 })
+          .lean<Array<{ _id: string }>>()
+          .exec()
+      : [];
 
   return {
     knownDegrees: new Set([
       ...newDegreeIds,
-      ...existingDegrees.map((degree) => String(degree._id)),
+      ...degreesFromDb.map((degree) => String(degree._id)),
     ]),
     knownCoursePools: new Set([
       ...newCoursePoolIds,
-      ...existingCoursePools.map((coursePool) => String(coursePool._id)),
+      ...poolsFromDb.map((pool) => String(pool._id)),
     ]),
     knownCourses: new Set([
       ...newCourseIds,
-      ...existingCourses.map((course) => String(course._id)),
+      ...coursesFromDb.map((course) => String(course._id)),
     ]),
   };
 }

--- a/Back-End/src/tests/applyCatalogPatch.test.ts
+++ b/Back-End/src/tests/applyCatalogPatch.test.ts
@@ -220,7 +220,13 @@ describe('applyCatalogPatch', () => {
       degrees: [],
       coursePools: [],
       courses: [],
-      diffs: [],
+      diffs: [
+        {
+          entityType: 'Degree',
+          entityId: 'D',
+          patch: [{ op: 'replace', path: '/name', value: 'D' }],
+        },
+      ],
     });
     expect(knownIds.knownDegrees.has('D')).toBe(true);
 
@@ -389,6 +395,103 @@ describe('applyCatalogPatch', () => {
             academicYear: '2027-2028',
             academicYearStart: 2027,
             patch: [{ op: 'replace', path: coursePoolsPath, value: ['P'] }],
+          },
+        ],
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('expands known course pools from DB degree when the diff does not touch /coursePools', async () => {
+    (Degree.find as jest.Mock)
+      .mockReturnValueOnce({
+        lean: jest.fn().mockReturnThis(),
+        exec: jest.fn().mockResolvedValue([
+          {
+            _id: 'Joint',
+            coursePools: ['POOL_A', 'POOL_B'],
+          },
+        ]),
+      })
+      .mockReturnValueOnce({
+        lean: jest.fn().mockReturnThis(),
+        exec: jest.fn().mockResolvedValue([
+          {
+            _id: 'Joint',
+            name: 'Joint',
+            totalCredits: 90,
+            coursePools: ['POOL_A', 'POOL_B'],
+            degreeType: 'Standalone',
+            ecpDegreeId: '',
+            baseAcademicYear: '2026-2027',
+          },
+        ]),
+      });
+
+    (CoursePool.find as jest.Mock)
+      .mockReturnValueOnce({
+        lean: jest.fn().mockReturnThis(),
+        exec: jest.fn().mockResolvedValue([
+          { _id: 'POOL_A', courses: ['COMP 248'] },
+          { _id: 'POOL_B', courses: [] },
+        ]),
+      })
+      .mockReturnValueOnce({
+        lean: jest.fn().mockReturnThis(),
+        exec: jest.fn().mockResolvedValue([
+          {
+            _id: 'POOL_A',
+            name: 'A',
+            creditsRequired: 3,
+            courses: ['COMP 248'],
+            baseAcademicYear: '2026-2027',
+          },
+          {
+            _id: 'POOL_B',
+            name: 'B',
+            creditsRequired: 0,
+            courses: [],
+            baseAcademicYear: '2026-2027',
+          },
+        ]),
+      });
+
+    (Course.find as jest.Mock)
+      .mockReturnValueOnce({
+        lean: jest.fn().mockReturnThis(),
+        exec: jest.fn().mockResolvedValue([{ _id: 'COMP 248' }]),
+      })
+      .mockReturnValueOnce({
+        lean: jest.fn().mockReturnThis(),
+        exec: jest.fn().mockResolvedValue([
+          {
+            _id: 'COMP 248',
+            title: 'Test',
+            description: '',
+            credits: 3,
+            baseAcademicYear: '2026-2027',
+          },
+        ]),
+      });
+
+    await expect(
+      validateReferences({
+        degrees: [],
+        coursePools: [],
+        courses: [],
+        diffs: [
+          {
+            _id: 'Degree:Joint:2026-2027',
+            entityType: 'Degree',
+            entityId: 'Joint',
+            academicYear: '2026-2027',
+            academicYearStart: 2026,
+            patch: [
+              {
+                op: 'replace',
+                path: '/ecpDegreeId',
+                value: 'ECP',
+              },
+            ],
           },
         ],
       }),


### PR DESCRIPTION
When a degree diff omits /coursePools (e.g. only ecpDegreeId changes), include pool and course IDs from the stored degree’s coursePools so loadCatalogState and assertResolvedReferences see existing MongoDB references.